### PR TITLE
PortaleCorrispettivi: rendi dinamici gli anni nel dettaglio impianto

### DIFF
--- a/Produzione/PortaleCorrispettivi/views.py
+++ b/Produzione/PortaleCorrispettivi/views.py
@@ -15,8 +15,7 @@ from PortaleCorrispettivi.utils import functions as fn
 from PortaleCorrispettivi.utils import graphics as gf
 
 from .models import *
-
-from .models import DiarioLetture
+# from .models import DiarioLetture
 
 
 impianti_m3s = ['ionico_foresta', 'ionico_SA3']
@@ -106,7 +105,8 @@ def impianto(request, nickname):
     dz_impianto = dz_impianti[nickname]
 
     # Ottieni gli anni disponibili per questo impianto
-    anni_disponibili = list(DiarioLetture.objects.filter(impianto=impianto).values_list('anno', flat=True).distinct())
+    # anni_disponibili = list(DiarioLetture.objects.filter(impianto=impianto).values_list('anno', flat=True).distinct())
+    anni_disponibili = list(range(2021, datetime.now().year + 1))
     print(anni_disponibili)
     
     # Passa l'anno al template


### PR DESCRIPTION
La lista anni della pagina dettaglio non viene più ricavata dai record
DiarioLetture ma generata dinamicamente dal 2021 all'anno corrente.
In questo modo non è più necessario inserire manualmente un record
DiarioLetture per ogni nuovo anno solo per visualizzare la scheda.