### PR TITLE
fix(saj): stabilizza il caricamento dei LED degli impianti

### DIFF
--- a/Produzione/MonitoraggioImpianti/API_SAJ.py
+++ b/Produzione/MonitoraggioImpianti/API_SAJ.py
@@ -52,6 +52,7 @@ PLANT_DEVICE_OVERRIDES = {
         "energy_field_name": "parallTodayPVEnergy",
     },
     "acquanova1150": {
+        "plant_id": "26049021801",
         "device_serial_numbers_to_query": [
             "C6V9104J2421E01334",
         ],
@@ -62,6 +63,7 @@ PLANT_DEVICE_OVERRIDES = {
         "energy_field_name": "todayPvEnergy",
     },
     "acquanova290": {
+        "plant_id": "26051023789",
         "device_serial_numbers_to_query": [
             "C6T9104J2314E00560",
         ],
@@ -363,12 +365,15 @@ def get_saj_day_data(impianto, start: datetime, end: datetime) -> tuple[pd.DataF
     token = saj_client.get_token()
     headers = saj_client.build_headers(token)
 
-    plants = saj_client.get_plants(headers)
-    plant = _find_matching_plant(plants, impianto)
-    if plant is None:
-        raise saj_client.SajApiError(f"Plant SAJ non trovato per {impianto.nome_impianto!r}")
+    plant_id = config.get("plant_id")
+    if not plant_id:
+        plants = saj_client.get_plants(headers)
+        plant = _find_matching_plant(plants, impianto)
+        if plant is None:
+            raise saj_client.SajApiError(f"Plant SAJ non trovato per {impianto.nome_impianto!r}")
+        plant_id = str(plant["plantId"])
 
-    devices = saj_client.get_devices(headers, plant_id=str(plant["plantId"]))
+    devices = saj_client.get_devices(headers, plant_id=str(plant_id))
     available_device_serials = {
         str(device.get("deviceSn"))
         for device in devices
@@ -396,7 +401,7 @@ def get_saj_day_data(impianto, start: datetime, end: datetime) -> tuple[pd.DataF
 
         ems_records = _get_ems_history_records(
             headers=headers,
-            plant_id=str(plant["plantId"]),
+            plant_id=str(plant_id),
             ems_sn=ems_sn,
             start=start,
             end=end,

--- a/Produzione/PortaleZilioService/API_inverter/saj_client.py
+++ b/Produzione/PortaleZilioService/API_inverter/saj_client.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta
+import threading
+import time
 
 import requests
 
@@ -8,6 +10,11 @@ import requests
 APP_ID = "VH_rQtUpniM"
 APP_SECRET = "hiDHa5riPzzTl2vixkVCWh4kpniM6ZrJZxkjunfShyuVrQtUFmPCbKu6oUaw7WAi"
 BASE_URL = "https://developer.saj-electric.com/prod-api"
+TOKEN_CACHE_SECONDS = 30 * 60
+
+_token_lock = threading.Lock()
+_cached_token: str | None = None
+_cached_token_valid_until = 0.0
 
 
 class SajApiError(RuntimeError):
@@ -15,16 +22,26 @@ class SajApiError(RuntimeError):
 
 
 def get_token() -> str:
-    response = requests.get(
-        f"{BASE_URL}/open/api/access_token",
-        params={"appId": APP_ID, "appSecret": APP_SECRET},
-        timeout=30,
-    )
-    response.raise_for_status()
-    token = response.json().get("data", {}).get("access_token")
-    if not token:
-        raise SajApiError("Missing SAJ access token in API response")
-    return token
+    global _cached_token, _cached_token_valid_until
+
+    now = time.monotonic()
+    with _token_lock:
+        if _cached_token and now < _cached_token_valid_until:
+            return _cached_token
+
+        response = requests.get(
+            f"{BASE_URL}/open/api/access_token",
+            params={"appId": APP_ID, "appSecret": APP_SECRET},
+            timeout=30,
+        )
+        response.raise_for_status()
+        token = response.json().get("data", {}).get("access_token")
+        if not token:
+            raise SajApiError("Missing SAJ access token in API response")
+
+        _cached_token = token
+        _cached_token_valid_until = time.monotonic() + TOKEN_CACHE_SECONDS
+        return token
 
 
 def build_headers(token: str) -> dict[str, str]:


### PR DESCRIPTION
- riutilizza il token SAJ con cache sincronizzata per evitare errori nelle richieste concorrenti della homepage
- configura esplicitamente i plant ID degli impianti Acquanova
- utilizza il plant ID configurato per recuperare i dispositivi SAJ senza dipendere dalla ricerca nell'elenco plant
- corregge la visualizzazione intermittente dei LED SAJ durante il caricamento simultaneo delle card